### PR TITLE
fix: исправить удаление фильма, использовать movieId

### DIFF
--- a/controllers/movies.js
+++ b/controllers/movies.js
@@ -52,7 +52,7 @@ module.exports.createMovie = (req, res, next) => {
 };
 
 module.exports.deleteMovie = (req, res, next) => {
-  Movie.findById(req.params._id)
+  Movie.findOne({ movieId: req.params._id.toString() })
     .then((movie) => {
       if (!movie) {
         throw new NotFoundError(MESSAGE_ABSENT_FILM_ID);

--- a/middlewares/validation.js
+++ b/middlewares/validation.js
@@ -41,7 +41,7 @@ const validateNewMovieData = celebrate({
 
 const validateDeletedMovieId = celebrate({
   [Segments.PARAMS]: Joi.object().keys({
-    _id: Joi.string().required().hex().length(24),
+    _id: Joi.string().required(),
   }),
 });
 


### PR DESCRIPTION
раньше фильмы удалялись по _id создаваемому в собственной базе, но нужно по универсальному movieId из БД movies-explorer
